### PR TITLE
Added Nomad and Consul CA Files

### DIFF
--- a/packer/hashibox.pkr.hcl
+++ b/packer/hashibox.pkr.hcl
@@ -94,6 +94,12 @@ build {
       "sudo dnf install -y consul-$CONSUL_VERSION* nomad-$NOMAD_VERSION* containernetworking-plugins",
 
       "sudo mkdir /opt/cni && sudo ln -s /usr/libexec/cni /opt/cni/bin",
+
+      # Provision Nomad and Consul CA's that can be later used for agent cert provisioning.
+      "sudo mkdir /etc/consul.d/certs && cd /etc/consul.d/certs ; sudo consul tls ca create",
+      "sudo mkdir /etc/nomad.d/certs && cd /etc/nomad.d/certs ; sudo consul tls ca create",
+
+      # Enabling of the services is the responsibility of the instance provisioning scripts.
       "sudo systemctl disable docker consul nomad"
     ]
   }


### PR DESCRIPTION
Bake the CA files for Nomad and Consul, which can be later used by the provision script to create agent certificates.

```
[ranjan@lima-murphy-srv-01 ~]$ ls -ld /etc/consul.d/certs/
drwxr-xr-x. 1 consul consul 84 May 31 11:19 /etc/consul.d/certs/

[ranjan@lima-murphy-srv-01 ~]$ ls -ld /etc/nomad.d/certs
drwxr-xr-x. 1 nomad nomad 84 May 31 11:19 /etc/nomad.d/certs

[ranjan@lima-murphy-srv-01 ~]$ ls -l /etc/consul.d/certs/
total 8
-rw-------. 1 root root  227 May 31 11:19 consul-agent-ca-key.pem
-rw-r--r--. 1 root root 1078 May 31 11:19 consul-agent-ca.pem

[ranjan@lima-murphy-srv-01 ~]$ ls -l /etc/nomad.d/certs/
total 8
-rw-------. 1 root root  227 May 31 11:19 consul-agent-ca-key.pem
-rw-r--r--. 1 root root 1078 May 31 11:19 consul-agent-ca.pem
```