### PR TITLE
Trying to simplify the provisioners for readability

### DIFF
--- a/scenarios/nomad-consul-quickstart/README.md
+++ b/scenarios/nomad-consul-quickstart/README.md
@@ -1,0 +1,71 @@
+# Scenario: Nomad Consul Quickstart
+
+This scenario deploys both Nomad and Consul with out any of the security configurations in place. This scenario is useful when you have to play around the features of Nomad (with or without Consul) and not worry about the security aspects.
+
+## Prerequsites
+
+This scenario has the following pre-requsites:
+
+* Shikari and Lima with Socket_VMNet configured
+* Requires a base VM image built using packer (`../../packer/hashibox.pkr.hcl`)
+* Uses `qemu` driver (you can use `vz` by modifying `vmType` in the template)
+* If running enterprise binaries, the Consul and Nomad licenses should be passed as environment variable (shown in the example below)
+
+### Usage
+
+#### Create
+
+Use the following command to launch the scenario using Shikari.
+
+```
+$ shikari create --name murphy \
+                 --servers 3 \
+                 --clients 3 \
+                 --env CONSUL_LICENSE=$(cat /location/to/consul/license) \
+                 --env NOMAD_LICENSE=$(cat /location/to/nomad/license) \
+                 --image ../../packer/.artifacts/<imagedir>/<image-file>.qcow2
+```
+
+#### List
+
+List the VMs in the cluster
+
+```
+shikari list
+CLUSTER       VM NAME             SATUS         DISK(GB)       MEMORY(GB)       CPUS
+murphy        murphy-cli-01       Running       100            4                4
+murphy        murphy-cli-02       Running       100            4                4
+murphy        murphy-cli-03       Running       100            4                4
+murphy        murphy-srv-01       Running       100            4                4
+murphy        murphy-srv-02       Running       100            4                4
+murphy        murphy-srv-03       Running       100            4                4
+```
+
+#### Access
+
+You can export the required environment variables to access both Nomad and Consul
+
+```
+$ eval $(shikari env -n murphy)
+
+$ consul members
+Node                Address              Status  Type    Build   Protocol  DC      Partition  Segment
+lima-murphy-srv-01  192.168.105.13:8301  alive   server  1.18.2  2         murphy  default    <all>
+lima-murphy-srv-02  192.168.105.12:8301  alive   server  1.18.2  2         murphy  default    <all>
+lima-murphy-srv-03  192.168.105.11:8301  alive   server  1.18.2  2         murphy  default    <all>
+lima-murphy-cli-01  192.168.105.10:8301  alive   client  1.18.2  2         murphy  default    <default>
+lima-murphy-cli-02  192.168.105.14:8301  alive   client  1.18.2  2         murphy  default    <default>
+lima-murphy-cli-03  192.168.105.9:8301   alive   client  1.18.2  2         murphy  default    <default>
+
+$ nomad node status
+ID        Node Pool  DC      Name                Class   Drain  Eligibility  Status
+94665b9b  default    murphy  lima-murphy-cli-01  <none>  false  eligible     ready
+83c90834  default    murphy  lima-murphy-cli-03  <none>  false  eligible     ready
+65ecc0ed  default    murphy  lima-murphy-cli-02  <none>  false  eligible     ready
+```
+
+#### Destroy
+
+```
+$ shikari destroy -f -n murphy
+```

--- a/scenarios/nomad-consul-quickstart/hashibox.yaml
+++ b/scenarios/nomad-consul-quickstart/hashibox.yaml
@@ -69,8 +69,15 @@ provision:
       #!/bin/bash
       cat <<-EOF > /etc/nomad.d/nomad.hcl
         data_dir  = "/opt/nomad/data"
-        bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+        bind_addr = "0.0.0.0"
         datacenter = "$CLUSTER"
+        log_level = "DEBUG"
+
+        advertise {
+          http = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+          rpc = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+          serf = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+        }
       EOF
 
   - mode: system # configure Nomad server settings

--- a/scenarios/nomad-consul-quickstart/hashibox.yaml
+++ b/scenarios/nomad-consul-quickstart/hashibox.yaml
@@ -2,33 +2,47 @@ images:
   # Try to use a local image first.
   - location: ~/artifacts/qemu/c-1.18-n-1.7/c-1.18-n-1.7.qcow2
 
-mounts: []
-containerd:
-  system: false
-  user: false
+
+# disable port-mapping, mounts, containerd etc
+plain: true
+
 provision:
-  - mode: system # configure Consul
+  - mode: system # install Consul and Nomad Licenses if any
     script: |
       #!/bin/bash
 
-      function setConfig {
-          local mode=$1
-          local cluster=$2
+      if [[ -n $CONSUL_LICENSE ]]; then
+        echo "CONSUL_LICENSE=$CONSUL_LICENSE" > /etc/consul.d/consul.env
+      fi
 
-          # Set the config files accordingly 
-          if [[ $mode == "server" ]]; then
+      if [[ -n $NOMAD_LICENSE ]]; then
+        echo "NOMAD_LICENSE=$NOMAD_LICENSE" > /etc/nomad.d/nomad.env
+      fi
+
+  - mode:  system # Configure Consul common settings
+    script: |
+      #!/bin/bash
+
+      # common config for Server and Client
       cat <<-EOF > /etc/consul.d/consul.hcl
         data_dir  = "/opt/consul/data"
         log_level  = "INFO"
         bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
         client_addr = "0.0.0.0"
-        retry_join = ["lima-$cluster-srv-01.local"]
-        datacenter = "$cluster"
+        retry_join = ["lima-$CLUSTER-srv-01.local"]
+        datacenter = "$CLUSTER"
 
         ui_config {
           enabled = true
         }
+      EOF
 
+  - mode: system # Configure Consul server settings
+    script: |
+      #!/bin/bash
+
+      if [[ $MODE == "server" ]]; then
+      cat <<-EOF > /etc/consul.d/server.hcl
         connect {
           enabled = true
         }
@@ -36,112 +50,59 @@ provision:
         server = true
         bootstrap_expect = $BOOTSTRAP_EXPECT
       EOF
+      fi
 
-          elif [[ $mode == "client" ]]; then
-      cat <<-EOF > /etc/consul.d/consul.hcl
-        data_dir  = "/opt/consul/data"
-        log_level  = "INFO"
-        bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
-        client_addr = "0.0.0.0"
-        retry_join = ["lima-$cluster-srv-01.local"]
-        datacenter = "$cluster"
-
-        connect {
-          enabled = true
-        }
-        server = false
-      EOF
-          else
-            echo "Invalid mode for setConfig"
-          fi
-        }
-
-          # Check if the environment variable 'MODE' is set
-          if [[ -n $MODE ]]; then
-              echo "MODE is set to: $MODE"
-          else
-              echo "MODE is not set."
-          fi
-
-          # Check if the environment variable 'CLUSTER' is set
-          if [[ -n $CLUSTER ]]; then
-              echo "CLUSTER is set to: $CLUSTER"
-          else
-              echo "CLUSTER is not set."
-          fi
-
-          if [[ -n $CONSUL_LICENSE ]]; then
-            echo "CONSUL_LICENSE=$CONSUL_LICENSE" > /etc/consul.d/consul.env
-          fi
-
-          setConfig $MODE $CLUSTER
-
-  - mode: system # configure Nomad
+  - mode: system # Configure Consul client settings
     script: |
-      #!/bin/bash    
-      function setConfig {
-          local mode=$1
-          local cluster=$2
+      #!/bin/bash
 
-          # Set the config files accordingly 
-          if [[ $mode == "server" ]]; then
+      if [[ $MODE == "client" ]]; then
+      cat <<-EOF > /etc/consul.d/client.hcl
+        ports {
+          grpc = 8502
+        }
+      EOF
+      fi
+
+  - mode: system # Configure Nomad common settings
+    script: |
+      #!/bin/bash
       cat <<-EOF > /etc/nomad.d/nomad.hcl
-          data_dir  = "/opt/nomad/data"
-          bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+        data_dir  = "/opt/nomad/data"
+        bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+        datacenter = "$CLUSTER"
+      EOF
 
-          server {
-          #license_path = "/etc/nomad.d/license.hclic"
-          enabled = true
-          bootstrap_expect = $BOOTSTRAP_EXPECT
+  - mode: system # configure Nomad server settings
+    script: |
+      #!/bin/bash
+
+      if [[ $MODE == "server" ]]; then
+      cat <<-EOF > /etc/nomad.d/server.hcl
+        server {
+        #license_path = "/etc/nomad.d/license.hclic"
+        enabled = true
+        bootstrap_expect = $BOOTSTRAP_EXPECT
 
           server_join {
-              retry_join = ["lima-$cluster-srv-01.local"]
+            retry_join = ["lima-$CLUSTER-srv-01.local"]
           }
-          }
-          datacenter = "$cluster"
-
-          client {
-          enabled = true
-          servers = ["lima-$cluster-srv-01.local"]
-          }
+        }
       EOF
+      fi
 
-          elif [[ $mode == "client" ]]; then
-      cat <<-EOF > /etc/nomad.d/nomad.hcl
-          data_dir  = "/opt/nomad/data"
-          bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
-          datacenter = "$cluster"
+  - mode: system # configure Nomad client settings
+    script: |
+      #!/bin/bash
 
-          client {
+      if [[ $MODE == "client" ]]; then
+      cat <<-EOF > /etc/nomad.d/client.hcl
+        client {
           enabled = true
-          servers = ["lima-$cluster-srv-01.local"]
-          }
+          servers = ["lima-$CLUSTER-srv-01.local"]
+        }
       EOF
-          else
-              echo "Invalid mode for setConfig"
-          fi
-      }
-
-
-          # Check if the environment variable 'MODE' is set
-          if [[ -n $MODE ]]; then
-              echo "MODE is set to: $MODE"
-          else
-              echo "MODE is not set."
-          fi
-
-          # Check if the environment variable 'CLUSTER' is set
-          if [[ -n $CLUSTER ]]; then
-              echo "CLUSTER is set to: $CLUSTER"
-          else
-              echo "CLUSTER is not set."
-          fi
-
-          if [[ -n $NOMAD_LICENSE ]]; then
-            echo "NOMAD_LICENSE=$NOMAD_LICENSE" > /etc/nomad.d/nomad.env
-          fi
-
-          setConfig $MODE $CLUSTER
+      fi
   - mode:
     script: |
       systemctl enable --now docker
@@ -154,4 +115,3 @@ provision:
 networks:
   - lima: shared
 vmType: qemu
-

--- a/scenarios/nomad-consul-secure/README.md
+++ b/scenarios/nomad-consul-secure/README.md
@@ -1,0 +1,71 @@
+# Scenario: Nomad Consul Quickstart
+
+This scenario deploys both Nomad and Consul with out any of the security configurations in place. This scenario is useful when you have to play around the features of Nomad (with or without Consul) and not worry about the security aspects.
+
+## Prerequsites
+
+This scenario has the following pre-requsites:
+
+* Shikari and Lima with Socket_VMNet configured
+* Requires a base VM image built using packer (`../../packer/hashibox.pkr.hcl`)
+* Uses `qemu` driver (you can use `vz` by modifying `vmType` in the template)
+* If running enterprise binaries, the Consul and Nomad licenses should be passed as environment variable (shown in the example below)
+
+### Usage
+
+#### Create
+
+Use the following command to launch the scenario using Shikari.
+
+```
+$ shikari create --name murphy \
+                 --servers 3 \
+                 --clients 3 \
+                 --env CONSUL_LICENSE=$(cat /location/to/consul/license) \
+                 --env NOMAD_LICENSE=$(cat /location/to/nomad/license) \
+                 --image ../../packer/.artifacts/<imagedir>/<image-file>.qcow2
+```
+
+#### List
+
+List the VMs in the cluster
+
+```
+shikari list
+CLUSTER       VM NAME             SATUS         DISK(GB)       MEMORY(GB)       CPUS
+murphy        murphy-cli-01       Running       100            4                4
+murphy        murphy-cli-02       Running       100            4                4
+murphy        murphy-cli-03       Running       100            4                4
+murphy        murphy-srv-01       Running       100            4                4
+murphy        murphy-srv-02       Running       100            4                4
+murphy        murphy-srv-03       Running       100            4                4
+```
+
+#### Access
+
+You can export the required environment variables to access both Nomad and Consul
+
+```
+$ eval $(shikari env -n murphy)
+
+$ consul members
+Node                Address              Status  Type    Build   Protocol  DC      Partition  Segment
+lima-murphy-srv-01  192.168.105.13:8301  alive   server  1.18.2  2         murphy  default    <all>
+lima-murphy-srv-02  192.168.105.12:8301  alive   server  1.18.2  2         murphy  default    <all>
+lima-murphy-srv-03  192.168.105.11:8301  alive   server  1.18.2  2         murphy  default    <all>
+lima-murphy-cli-01  192.168.105.10:8301  alive   client  1.18.2  2         murphy  default    <default>
+lima-murphy-cli-02  192.168.105.14:8301  alive   client  1.18.2  2         murphy  default    <default>
+lima-murphy-cli-03  192.168.105.9:8301   alive   client  1.18.2  2         murphy  default    <default>
+
+$ nomad node status
+ID        Node Pool  DC      Name                Class   Drain  Eligibility  Status
+94665b9b  default    murphy  lima-murphy-cli-01  <none>  false  eligible     ready
+83c90834  default    murphy  lima-murphy-cli-03  <none>  false  eligible     ready
+65ecc0ed  default    murphy  lima-murphy-cli-02  <none>  false  eligible     ready
+```
+
+#### Destroy
+
+```
+$ shikari destroy -f -n murphy
+```

--- a/scenarios/nomad-consul-secure/hashibox.yaml
+++ b/scenarios/nomad-consul-secure/hashibox.yaml
@@ -1,0 +1,234 @@
+images:
+  # Try to use a local image first.
+  - location: ~/artifacts/qemu/c-1.18-n-1.7/c-1.18-n-1.7.qcow2
+
+
+# disable port-mapping, mounts, containerd etc
+plain: true
+
+provision:
+  - mode: system # install Consul and Nomad Licenses if any
+    script: |
+      #!/bin/bash
+
+      if [[ -n $CONSUL_LICENSE ]]; then
+        echo "CONSUL_LICENSE=$CONSUL_LICENSE" > /etc/consul.d/consul.env
+      fi
+
+      if [[ -n $NOMAD_LICENSE ]]; then
+        echo "NOMAD_LICENSE=$NOMAD_LICENSE" > /etc/nomad.d/nomad.env
+      fi
+
+  - mode:  system # Configure Consul common settings
+    script: |
+      #!/bin/bash
+
+      # common config for Server and Client
+      cat <<-EOF > /etc/consul.d/consul.hcl
+        data_dir  = "/opt/consul/data"
+        log_level  = "INFO"
+        bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+        client_addr = "0.0.0.0"
+        retry_join = ["lima-$CLUSTER-srv-01.local"]
+        datacenter = "$CLUSTER"
+
+        ui_config {
+          enabled = true
+        }
+      EOF
+
+      cat <<-EOF > /etc/consul.d/acl.hcl
+        acl {
+          enabled = true
+          default_policy = "deny"
+          down_policy = "extend-cache"
+          
+          enable_token_persistence = true
+
+          tokens {
+            initial_management = "root"
+            agent = "root"
+          }
+        }
+      EOF
+
+
+      ## Generate Consul Server Certificates
+
+      cd /etc/consul.d/certs
+      consul tls cert create -$MODE -dc $CLUSTER -additional-ipaddress $(ip -json -4 addr show lima0  | jq -r '.[] | .addr_info[].local')
+      chown consul:consul /etc/consul.d/certs/*
+      chmod 644 /etc/consul.d/certs/*
+
+      cat <<-EOF > /etc/consul.d/tls.hcl
+        tls {
+          defaults {
+            ca_file = "/etc/consul.d/certs/consul-agent-ca.pem"
+            cert_file = "/etc/consul.d/certs/$CLUSTER-$MODE-consul-0.pem"
+            key_file = "/etc/consul.d/certs/$CLUSTER-$MODE-consul-0-key.pem"
+            verify_server_hostname = true
+            verify_incoming = true
+            verify_outgoing = true
+          }
+          grpc {
+            verify_incoming = false
+          }
+          https {
+            verify_incoming = false
+          }
+        }
+      EOF
+
+  - mode: system # Configure Consul server settings
+    script: |
+      #!/bin/bash
+
+      if [[ $MODE == "server" ]]; then
+      cat <<-EOF > /etc/consul.d/server.hcl
+        connect {
+          enabled = true
+        }
+
+        server = true
+        bootstrap_expect = $BOOTSTRAP_EXPECT
+      EOF
+
+      cat <<-EOF > /etc/consul.d/ports.hcl
+      ports {
+        https = 8501
+      }
+      EOF
+
+      fi
+
+  - mode: system # Configure Consul client settings
+    script: |
+      #!/bin/bash
+
+      if [[ $MODE == "client" ]]; then
+      cat <<-EOF > /etc/consul.d/client.hcl
+        ports {
+          grpc = 8502
+          grpc_tls = 8503
+          https = 8501
+        }
+      EOF
+      fi
+
+  - mode: system # Configure Nomad common settings
+    script: |
+      #!/bin/bash
+      cat <<-EOF > /etc/nomad.d/nomad.hcl
+        data_dir  = "/opt/nomad/data"
+        bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+        datacenter = "$CLUSTER"
+
+        addresses {
+          http = "0.0.0.0"
+        }
+      EOF
+
+      cat <<-EOF > /etc/nomad.d/acl.hcl
+      acl {
+        enabled = true
+      }
+      EOF
+
+      ## Generate TLS Certificates
+
+      cd /etc/nomad.d/certs
+      nomad tls cert create -$MODE -additional-ipaddress $(ip -json -4 addr show lima0  | jq -r '.[] | .addr_info[].local')
+
+      cat <<-EOF > /etc/nomad.d/tls.hcl
+      tls {
+        http = true
+        rpc = true
+
+        ca_file = "/etc/nomad.d/certs/nomad-agent-ca.pem"
+        cert_file = "/etc/nomad.d/certs/global-$MODE-nomad.pem"
+        key_file = "/etc/nomad.d/certs/global-$MODE-nomad-key.pem"
+
+        verify_server_hostname = true
+      }
+      EOF
+
+      cat <<-EOF > /etc/nomad.d/consul.hcl
+      consul {
+        address = "127.0.0.1:8501"
+        token = "root"
+        ssl = true
+        ca_file = "/etc/consul.d/certs/consul-agent-ca.pem"
+        grpc_ca_file = "/etc/consul.d/certs/consul-agent-ca.pem"
+      }
+      EOF
+
+  - mode: system # configure Nomad server settings
+    script: |
+      #!/bin/bash
+
+      if [[ $MODE == "server" ]]; then
+      cat <<-EOF > /etc/nomad.d/server.hcl
+        server {
+        #license_path = "/etc/nomad.d/license.hclic"
+        enabled = true
+        bootstrap_expect = $BOOTSTRAP_EXPECT
+
+          server_join {
+            retry_join = ["lima-$CLUSTER-srv-01.local"]
+          }
+        }
+      EOF
+      fi
+
+  - mode: system # configure Nomad client settings
+    script: |
+      #!/bin/bash
+
+      if [[ $MODE == "client" ]]; then
+      cat <<-EOF > /etc/nomad.d/client.hcl
+        client {
+          enabled = true
+          servers = ["lima-$CLUSTER-srv-01.local"]
+        }
+      EOF
+      fi
+  - mode: system
+    script: |
+      systemctl enable --now docker
+      systemctl enable --now nomad consul
+
+  - mode: system # Bootstrap Nomad ACL
+    script: |
+      #!/bin/sh
+      if [[ $MODE == "server" ]]; then
+      # Wait for nomad servers to come up and bootstrap nomad ACL
+      for i in {1..10}; do
+          # add sleep 5 secs
+          set +e
+          sleep 5
+          export NOMAD_ADDR=https://127.0.0.1:4646
+          export NOMAD_CACERT=/etc/nomad.d/certs/nomad-agent-ca.pem
+          OUTPUT=$(echo "00000000-0000-0000-0000-000000000000"|nomad acl bootstrap - 2>&1)
+          # checks if the previous command (nomad acl bootstrap) failed (non-zero exit status).
+          if [ $? -ne 0 ]; then
+              echo "nomad acl bootstrap: $OUTPUT"
+              if [[ "$OUTPUT" = *"No cluster leader"* ]]; then
+                  echo "nomad has no cluster leader"
+                  continue
+              else
+                  echo "nomad already bootstrapped"
+                  exit 0
+              fi
+          fi
+          set -e
+      done
+      fi
+      
+  - mode: user
+    script: |
+      #!/bin/sh
+      nomad -autocomplete-install
+      consul -autocomplete-install
+networks:
+  - lima: shared
+vmType: qemu

--- a/scenarios/nomad-consul-secure/hashibox.yaml
+++ b/scenarios/nomad-consul-secure/hashibox.yaml
@@ -112,6 +112,8 @@ provision:
           grpc_tls = 8503
           https = 8501
         }
+
+        recursors = ["1.1.1.1", "8.8.8.8"]
       EOF
       fi
 
@@ -120,11 +122,14 @@ provision:
       #!/bin/bash
       cat <<-EOF > /etc/nomad.d/nomad.hcl
         data_dir  = "/opt/nomad/data"
-        bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+        # bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+        bind_addr = "0.0.0.0"
         datacenter = "$CLUSTER"
 
-        addresses {
-          http = "0.0.0.0"
+        advertise {
+          http = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+          rpc = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+          serf = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
         }
       EOF
 
@@ -189,6 +194,8 @@ provision:
         client {
           enabled = true
           servers = ["lima-$CLUSTER-srv-01.local"]
+
+          network_interface = "lima0"
         }
       EOF
       fi

--- a/scenarios/nomad-consul-secure/hashibox.yaml
+++ b/scenarios/nomad-consul-secure/hashibox.yaml
@@ -3,7 +3,6 @@ images:
   - location: ~/artifacts/qemu/c-1.18-n-1.7/c-1.18-n-1.7.qcow2
 
 
-# disable port-mapping, mounts, containerd etc
 plain: true
 
 provision:
@@ -26,7 +25,7 @@ provision:
       # common config for Server and Client
       cat <<-EOF > /etc/consul.d/consul.hcl
         data_dir  = "/opt/consul/data"
-        log_level  = "INFO"
+        log_level  = "DEBUG"
         bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
         client_addr = "0.0.0.0"
         retry_join = ["lima-$CLUSTER-srv-01.local"]
@@ -47,7 +46,6 @@ provision:
 
           tokens {
             initial_management = "root"
-            agent = "root"
           }
         }
       EOF
@@ -122,9 +120,9 @@ provision:
       #!/bin/bash
       cat <<-EOF > /etc/nomad.d/nomad.hcl
         data_dir  = "/opt/nomad/data"
-        # bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
         bind_addr = "0.0.0.0"
         datacenter = "$CLUSTER"
+        log_level = "DEBUG"
 
         advertise {
           http = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
@@ -207,7 +205,7 @@ provision:
   - mode: system # Bootstrap Nomad ACL
     script: |
       #!/bin/sh
-      if [[ $MODE == "server" ]]; then
+      if echo $HOSTNAME | grep srv-01$ > /dev/null 2>&1; then
       # Wait for nomad servers to come up and bootstrap nomad ACL
       for i in {1..10}; do
           # add sleep 5 secs
@@ -229,6 +227,35 @@ provision:
           fi
           set -e
       done
+      fi
+
+  - mode: system
+    script: |
+      #!/bin/sh
+
+      export CONSUL_HTTP_ADDR=https://localhost:8501
+      export CONSUL_CACERT=/etc/consul.d/certs/consul-agent-ca.pem
+      export CONSUL_HTTP_TOKEN=root
+
+      until curl -s -k ${CONSUL_HTTP_ADDR}/v1/status/leader | grep 8300; do
+        echo "Waiting for Consul to start"
+        sleep 1
+      done
+
+      agent_token=$(consul acl token create -node-identity $(hostname):$CLUSTER -format json | jq -r '.SecretID')
+      consul acl set-agent-token agent $agent_token
+
+
+      # Update anonymous token policy from the first server
+
+      if echo $HOSTNAME | grep srv-01$ > /dev/null 2>&1; then
+        if consul version | head -n 1 | grep ent > /dev/null 2>&1; then
+          acl_rule='partition "default" { namespace "default" { query_prefix "" { policy = "read" } } } partition_prefix "" { namespace_prefix "" { node_prefix "" { policy = "read" } service_prefix "" { policy = "read" } } }'
+        else
+          acl_rule='node_prefix "" { policy = "read" } service_prefix "" { policy = "read" } query_prefix "" { policy = "read" }'
+        fi
+        echo $acl_rule | consul acl policy create -name anon-policy -rules=-
+        consul acl token update -accessor-id=00000000-0000-0000-0000-000000000002 --policy-name anon-policy
       fi
       
   - mode: user

--- a/scenarios/nomad-only-quickstart/README.md
+++ b/scenarios/nomad-only-quickstart/README.md
@@ -1,0 +1,71 @@
+# Scenario: Nomad Consul Quickstart
+
+This scenario deploys both Nomad and Consul with out any of the security configurations in place. This scenario is useful when you have to play around the features of Nomad (with or without Consul) and not worry about the security aspects.
+
+## Prerequsites
+
+This scenario has the following pre-requsites:
+
+* Shikari and Lima with Socket_VMNet configured
+* Requires a base VM image built using packer (`../../packer/hashibox.pkr.hcl`)
+* Uses `qemu` driver (you can use `vz` by modifying `vmType` in the template)
+* If running enterprise binaries, the Consul and Nomad licenses should be passed as environment variable (shown in the example below)
+
+### Usage
+
+#### Create
+
+Use the following command to launch the scenario using Shikari.
+
+```
+$ shikari create --name murphy \
+                 --servers 3 \
+                 --clients 3 \
+                 --env CONSUL_LICENSE=$(cat /location/to/consul/license) \
+                 --env NOMAD_LICENSE=$(cat /location/to/nomad/license) \
+                 --image ../../packer/.artifacts/<imagedir>/<image-file>.qcow2
+```
+
+#### List
+
+List the VMs in the cluster
+
+```
+shikari list
+CLUSTER       VM NAME             SATUS         DISK(GB)       MEMORY(GB)       CPUS
+murphy        murphy-cli-01       Running       100            4                4
+murphy        murphy-cli-02       Running       100            4                4
+murphy        murphy-cli-03       Running       100            4                4
+murphy        murphy-srv-01       Running       100            4                4
+murphy        murphy-srv-02       Running       100            4                4
+murphy        murphy-srv-03       Running       100            4                4
+```
+
+#### Access
+
+You can export the required environment variables to access both Nomad and Consul
+
+```
+$ eval $(shikari env -n murphy)
+
+$ consul members
+Node                Address              Status  Type    Build   Protocol  DC      Partition  Segment
+lima-murphy-srv-01  192.168.105.13:8301  alive   server  1.18.2  2         murphy  default    <all>
+lima-murphy-srv-02  192.168.105.12:8301  alive   server  1.18.2  2         murphy  default    <all>
+lima-murphy-srv-03  192.168.105.11:8301  alive   server  1.18.2  2         murphy  default    <all>
+lima-murphy-cli-01  192.168.105.10:8301  alive   client  1.18.2  2         murphy  default    <default>
+lima-murphy-cli-02  192.168.105.14:8301  alive   client  1.18.2  2         murphy  default    <default>
+lima-murphy-cli-03  192.168.105.9:8301   alive   client  1.18.2  2         murphy  default    <default>
+
+$ nomad node status
+ID        Node Pool  DC      Name                Class   Drain  Eligibility  Status
+94665b9b  default    murphy  lima-murphy-cli-01  <none>  false  eligible     ready
+83c90834  default    murphy  lima-murphy-cli-03  <none>  false  eligible     ready
+65ecc0ed  default    murphy  lima-murphy-cli-02  <none>  false  eligible     ready
+```
+
+#### Destroy
+
+```
+$ shikari destroy -f -n murphy
+```

--- a/scenarios/nomad-only-quickstart/hashibox.yaml
+++ b/scenarios/nomad-only-quickstart/hashibox.yaml
@@ -24,8 +24,14 @@ provision:
       #!/bin/bash
       cat <<-EOF > /etc/nomad.d/nomad.hcl
         data_dir  = "/opt/nomad/data"
-        bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
-        datacenter = "$CLUSTER"
+        bind_addr = "0.0.0.0"
+        log_level = "DEBUG"
+
+        advertise {
+          http = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+          rpc = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+          serf = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+        }
       EOF
 
   - mode: system # configure Nomad server settings

--- a/scenarios/nomad-only-quickstart/hashibox.yaml
+++ b/scenarios/nomad-only-quickstart/hashibox.yaml
@@ -2,82 +2,71 @@ images:
   # Try to use a local image first.
   - location: ~/artifacts/qemu/c-1.18-n-1.7/c-1.18-n-1.7.qcow2
 
-mounts: []
-containerd:
-  system: false
-  user: false
+
+# disable port-mapping, mounts, containerd etc
+plain: true
+
 provision:
-  - mode: system # configure Nomad
+  - mode: system # install Consul and Nomad Licenses if any
     script: |
-      #!/bin/bash    
-      function setConfig {
-          local mode=$1
-          local cluster=$2
+      #!/bin/bash
 
-          # Set the config files accordingly 
-          if [[ $mode == "server" ]]; then
+      if [[ -n $CONSUL_LICENSE ]]; then
+        echo "CONSUL_LICENSE=$CONSUL_LICENSE" > /etc/consul.d/consul.env
+      fi
+
+      if [[ -n $NOMAD_LICENSE ]]; then
+        echo "NOMAD_LICENSE=$NOMAD_LICENSE" > /etc/nomad.d/nomad.env
+      fi
+
+  - mode: system # Configure Nomad common settings
+    script: |
+      #!/bin/bash
       cat <<-EOF > /etc/nomad.d/nomad.hcl
-          data_dir  = "/opt/nomad/data"
-          bind_addr = "0.0.0.0"
+        data_dir  = "/opt/nomad/data"
+        bind_addr = {{ "\"{{ GetInterfaceIP \\\"lima0\\\"}}\"" }}
+        datacenter = "$CLUSTER"
+      EOF
 
-          server {
-          #license_path = "/etc/nomad.d/license.hclic"
-          enabled = true
-          bootstrap_expect = 1
+  - mode: system # configure Nomad server settings
+    script: |
+      #!/bin/bash
+
+      if [[ $MODE == "server" ]]; then
+      cat <<-EOF > /etc/nomad.d/server.hcl
+        server {
+        #license_path = "/etc/nomad.d/license.hclic"
+        enabled = true
+        bootstrap_expect = $BOOTSTRAP_EXPECT
 
           server_join {
-              retry_join = ["lima-$cluster-srv-01.internal"]
+            retry_join = ["lima-$CLUSTER-srv-01.local"]
           }
-          }
-          datacenter = "$cluster"
-
-          client {
-          enabled = true
-          servers = ["lima-$cluster-srv-01.internal"]
-          }
+        }
       EOF
+      fi
 
-          elif [[ $mode == "client" ]]; then
-      cat <<-EOF > /etc/nomad.d/nomad.hcl
-          data_dir  = "/opt/nomad/data"
-          bind_addr = "0.0.0.0"
-          datacenter = "$cluster"
+  - mode: system # configure Nomad client settings
+    script: |
+      #!/bin/bash
 
-          client {
+      if [[ $MODE == "client" ]]; then
+      cat <<-EOF > /etc/nomad.d/client.hcl
+        client {
           enabled = true
-          servers = ["lima-$cluster-srv-01.internal"]
-          }
+          servers = ["lima-$CLUSTER-srv-01.local"]
+        }
       EOF
-          else
-              echo "Invalid mode for setConfig"
-          fi
-      }
-
-
-          # Check if the environment variable 'MODE' is set
-          if [[ -n $MODE ]]; then
-              echo "MODE is set to: $MODE"
-          else
-              echo "MODE is not set."
-          fi
-
-          # Check if the environment variable 'CLUSTER' is set
-          if [[ -n $CLUSTER ]]; then
-              echo "CLUSTER is set to: $CLUSTER"
-          else
-              echo "CLUSTER is not set."
-          fi
-
-          setConfig $MODE $CLUSTER
+      fi
   - mode:
     script: |
       systemctl enable --now docker
-      systemctl enable --now nomad 
+      systemctl enable --now nomad
   - mode: user
     script: |
       #!/bin/sh
       nomad -autocomplete-install
+      consul -autocomplete-install
 networks:
-  - lima: user-v2
+  - lima: shared
 vmType: qemu
-


### PR DESCRIPTION
Refactor the provisioner to be simpler and separate by splitting the script into separate categories like `common`, `server`, `client`, and post-deployment (like ACL bootstrapping, etc.).