### PR TITLE
Add client network_interface

### DIFF
--- a/scenarios/nomad-consul-quickstart/hashibox.yaml
+++ b/scenarios/nomad-consul-quickstart/hashibox.yaml
@@ -110,6 +110,8 @@ provision:
         client {
           enabled = true
           servers = ["lima-$CLUSTER-srv-01.local"]
+
+          network_interface = "lima0"
         }
       EOF
       fi


### PR DESCRIPTION
Add `client.network_interface` for picking the right interface and advertising the right IP in case of servers having multiple NICs.