### PR TITLE
Patch kubeconfig to have the lima0 IP

### DIFF
--- a/scenarios/k3s-multinode/README.md
+++ b/scenarios/k3s-multinode/README.md
@@ -16,7 +16,7 @@ When `-s` is > 1, HA will be configured. All the control-plane nodes gets the No
 The following steps will build a Vault cluster.
 
 ```
-shikari create -n k3s -s 3 -c 3
+shikari create -n k3s -s 3 -c 1
 ```
 
 ### Access
@@ -25,8 +25,20 @@ Setup the KUBECONFIG file to access the cluster.
 
 ```
 limactl cp k3s-srv-01:/etc/rancher/k3s/k3s.yaml $(limactl ls k3s-srv-01 --format="{{.Dir}}")/kubeconfig.yaml
-
+export KUBECONFIG=$(limactl ls k3s-srv-01 --format="{{.Dir}}")/kubeconfig.yaml
 ```
+
+> From Shikari v0.4.0, you can use the below command instead of manually copying and setting env variables.
+>```
+>$ eval $(shikari env -n k3s k3s)
+>
+>$ kubectl get nodes -o wide
+>NAME              STATUS   ROLES                       AGE   VERSION        INTERNAL-IP       EXTERNAL-IP   OS-IMAGE           KERNEL-VERSION     CONTAINER-RUNTIME
+>lima-k3s-cli-01   Ready    <none>                      11m   v1.29.6+k3s1   192.168.105.101   <none>        Ubuntu 24.04 LTS   6.8.0-31-generic   containerd://1.7.17-k3s1
+>lima-k3s-srv-01   Ready    control-plane,etcd,master   11m   v1.29.6+k3s1   192.168.105.99    <none>        Ubuntu 24.04 LTS   6.8.0-31-generic   containerd://1.7.17-k3s1
+>lima-k3s-srv-02   Ready    control-plane,etcd,master   11m   v1.29.6+k3s1   192.168.105.100   <none>        Ubuntu 24.04 LTS   6.8.0-31-generic   containerd://1.7.17-k3s1
+>lima-k3s-srv-03   Ready    control-plane,etcd,master   11m   v1.29.6+k3s1   192.168.105.103   <none>        Ubuntu 24.04 LTS   6.8.0-31-generic   containerd://1.7.17-k3s1
+>```
 
 ### Destroy
 

--- a/scenarios/k3s-multinode/hashibox.yaml
+++ b/scenarios/k3s-multinode/hashibox.yaml
@@ -95,6 +95,9 @@ provision:
       curl -sfL https://get.k3s.io | K3S_TOKEN=${K3S_TOKEN} INSTALL_K3S_EXEC="${K3S_MODE} --node-taint=${K3S_NODE_TAINT} --flannel-iface=lima0 --node-ip ${LIMA_IP} ${K3S_URL_ARG} ${K3S_CLUSTER_INIT_ARG} ${K3S_KUBECONFIG_MODE_ARG}" sh -
     fi
 
+    # Set the cluster server URL to the lima0 interface IP so that it can be copied to host and access the cluster.
+    kubectl config set-cluster default --server=https://$LIMA_IP:6443
+
 networks:
   - lima: shared
 env:


### PR DESCRIPTION
This allows the Kubeconfig to be copied to the host and access the cluster using kubectl.