### PR TITLE
Change the Packer output directory to be under HOME

### DIFF
--- a/packer/hashibox.pkr.hcl
+++ b/packer/hashibox.pkr.hcl
@@ -79,11 +79,11 @@ source "qemu" "hashibox" {
   disk_image       = true
 
   format       = "qcow2"
-  vm_name      = "c-${var.consul_version}-n-${var.nomad_version}-v-${var.vault_version}.qcow2"
+  vm_name      = "hashibox.qcow2"
   boot_command = []
   net_device   = "virtio-net"
 
-  output_directory = ".artifacts/c-${var.consul_version}-n-${var.nomad_version}-v-${var.vault_version}-b-${var.boundary_version}"
+  output_directory = pathexpand("~/.shikari/c-${var.consul_version}-n-${var.nomad_version}-v-${var.vault_version}-b-${var.boundary_version}")
 
   cpus   = 8
   memory = 5120


### PR DESCRIPTION
This PR introduces the following changes and each of the change is backed with the reasoning:

* Change the output directory to be under HOME
  * One single place to find all the images
  * Shorter path names when passed into -i and also in the `shikari list` output
  * Easier to refer in documentation etc, instead of the current `../../packer` relative path

* Change the image name to hashibox.qcow2
  * Again shorter overall path name to the images
  * There is no need of repeating the version names in the image file (when the parent directory already has it)