### PR TITLE
Update Nomad Scenarios for Multi-DC single Region Support

### DIFF
--- a/scenarios/nomad-consul-quickstart/hashibox.yaml
+++ b/scenarios/nomad-consul-quickstart/hashibox.yaml
@@ -70,10 +70,14 @@ provision:
   - mode: system # Configure Nomad common settings
     script: |
       #!/bin/bash
+
+      # allow the DC name to be overriden by NOMAD_DC environment variable
+      NOMAD_DC_NAME="${NOMAD_DC:-$SHIKARI_CLUSTER_NAME}"
+
       cat <<-EOF > /etc/nomad.d/nomad.hcl
         data_dir  = "/opt/nomad/data"
         bind_addr = "0.0.0.0"
-        datacenter = "${SHIKARI_CLUSTER_NAME}"
+        datacenter = "${NOMAD_DC_NAME}"
         log_level = "DEBUG"
 
         advertise {

--- a/scenarios/nomad-consul-secure/hashibox.yaml
+++ b/scenarios/nomad-consul-secure/hashibox.yaml
@@ -153,10 +153,14 @@ provision:
   - mode: system # Configure Nomad common settings
     script: |
       #!/bin/bash
+
+      # allow the DC name to be overriden by NOMAD_DC environment variable
+      NOMAD_DC_NAME="${NOMAD_DC:-$SHIKARI_CLUSTER_NAME}"
+
       cat <<-EOF > /etc/nomad.d/nomad.hcl
         data_dir  = "/opt/nomad/data"
         bind_addr = "0.0.0.0"
-        datacenter = "${SHIKARI_CLUSTER_NAME}"
+        datacenter = "${NOMAD_DC_NAME}"
         log_level = "DEBUG"
 
         advertise {

--- a/scenarios/nomad-consul-vault-quickstart/hashibox.yaml
+++ b/scenarios/nomad-consul-vault-quickstart/hashibox.yaml
@@ -183,10 +183,14 @@ provision:
   - mode: system # Configure Nomad Common Settings
     script: |
       #!/bin/bash
+
+      # allow the DC name to be overriden by NOMAD_DC environment variable
+      NOMAD_DC_NAME="${NOMAD_DC:-$SHIKARI_CLUSTER_NAME}"
+
       cat <<-EOF > /etc/nomad.d/nomad.hcl
         data_dir  = "/opt/nomad/data"
         bind_addr = "0.0.0.0"
-        datacenter = "${SHIKARI_CLUSTER_NAME}"
+        datacenter = "${NOMAD_DC_NAME}"
         log_level = "DEBUG"
 
         advertise {

--- a/scenarios/nomad-only-quickstart/hashibox.yaml
+++ b/scenarios/nomad-only-quickstart/hashibox.yaml
@@ -22,9 +22,14 @@ provision:
   - mode: system # Configure Nomad common settings
     script: |
       #!/bin/bash
+
+      # allow the DC name to be overriden by NOMAD_DC environment variable
+      NOMAD_DC_NAME="${NOMAD_DC:-$SHIKARI_CLUSTER_NAME}"
+
       cat <<-EOF > /etc/nomad.d/nomad.hcl
         data_dir  = "/opt/nomad/data"
         bind_addr = "0.0.0.0"
+        datacenter = "${NOMAD_DC_NAME}"
         log_level = "DEBUG"
 
         advertise {


### PR DESCRIPTION
The nomad scenarios now allows to have custom DC names and this can be used with the scale option to have single-region multi-dc clusters.