### PR TITLE
Move the Vault Cert directory to be consistent with other products

### DIFF
--- a/packer/hashibox.pkr.hcl
+++ b/packer/hashibox.pkr.hcl
@@ -141,9 +141,11 @@ build {
       "curl -L -o /tmp/consul-cni.zip https://releases.hashicorp.com/consul-cni/$${CONSUL_CNI_VERSION}/consul-cni_$${CONSUL_CNI_VERSION}_linux_$( [ $(uname -m) = aarch64 ] && echo arm64 || echo amd64).zip",
       "sudo unzip /tmp/consul-cni.zip -d /usr/libexec/cni/",
 
-      # Provision Nomad and Consul CA's that can be later used for agent cert provisioning.
+      # Provision Nomad, Consul and Vault CA's that can be later used for agent cert provisioning.
       "sudo mkdir /etc/consul.d/certs && cd /etc/consul.d/certs ; sudo consul tls ca create",
       "sudo mkdir /etc/nomad.d/certs && cd /etc/nomad.d/certs ; sudo nomad tls ca create",
+      # this will generate CA with the name vault-agent-ca.pem. Ensure the cert generation commands out of these CA use `-domain vault`
+      "sudo mkdir /etc/vault.d/certs && cd /etc/vault.d/certs ; sudo consul tls ca create -domain vault",
 
       # Install exec2 driver and copy under /opt/nomad/data/plugins dir
       "sudo dnf install -y nomad-driver-exec2 --enablerepo hashicorp-test",
@@ -153,6 +155,7 @@ build {
       # Set permissions for the certs directory
       "sudo chown consul:consul /etc/consul.d/certs",
       "sudo chown nomad:nomad /etc/nomad.d/certs",
+      "sudo chown vault:vault /etc/vault.d/certs",
 
       # Enabling of the services is the responsibility of the instance provisioning scripts.
       "sudo systemctl disable docker consul nomad"

--- a/scenarios/vault-consul-storage/hashibox.yaml
+++ b/scenarios/vault-consul-storage/hashibox.yaml
@@ -153,13 +153,11 @@ provision:
         exit 0
       fi
 
-      cd /opt/vault/tls
+      cd /etc/vault.d/certs
 
-      cp /etc/consul.d/certs/* .
+      consul tls cert create -domain vault -server -additional-ipaddress $(ip -json -4 addr show lima0  | jq -r '.[] | .addr_info[].local') -additional-dnsname ${HOSTNAME}.local
 
-      consul tls cert create -server -additional-ipaddress $(ip -json -4 addr show lima0  | jq -r '.[] | .addr_info[].local') -additional-dnsname ${HOSTNAME}.local
-
-      chown vault:vault /opt/vault/tls/*
+      chown -R vault:vault /etc/vault.d/certs/*
 
   - mode: system # configure Vault Server
     script: |
@@ -183,15 +181,15 @@ provision:
         address = "localhost:8501"
         token   = "11111111-1111-1111-1111-111111111111"
         scheme = "https"
-        tls_ca_file = "/opt/vault/tls/consul-agent-ca.pem"
+        tls_ca_file = "/etc/consul.d/certs/consul-agent-ca.pem"
       }
 
       listener "tcp" {
         address       = "0.0.0.0:8200"
         
-        tls_cert_file       = "/opt/vault/tls/dc1-server-consul-0.pem"
-        tls_key_file        = "/opt/vault/tls/dc1-server-consul-0-key.pem"
-        tls_client_ca_file  = "/opt/vault/tls/consul-agent-ca.pem"
+        tls_cert_file       = "/etc/vault.d/certs/dc1-server-vault-0.pem"
+        tls_key_file        = "/etc/vault.d/certs/dc1-server-vault-0-key.pem"
+        tls_client_ca_file  = "/etc/vault.d/certs/vault-agent-ca.pem"
         
         cluster_address = "0.0.0.0:8201"
       }
@@ -218,11 +216,11 @@ provision:
       fi
 
       export VAULT_ADDR=https://127.0.0.1:8200
-      export VAULT_CACERT=/opt/vault/tls/consul-agent-ca.pem
+      export VAULT_CACERT=/etc/vault.d/certs/vault-agent-ca.pem
       
       if [[ "$HOSTNAME" == *"01"* ]]; then
         
-        until curl -s --cacert /opt/vault/tls/consul-agent-ca.pem $VAULT_ADDR/v1/sys/health; do
+        until curl -s --cacert /etc/vault.d/certs/vault-agent-ca.pem $VAULT_ADDR/v1/sys/health; do
           echo "Waiting for Vault"
         done
 

--- a/scenarios/vault-integrated-storage/hashibox.yaml
+++ b/scenarios/vault-integrated-storage/hashibox.yaml
@@ -17,13 +17,11 @@ provision:
         exit 0
       fi
 
-      cd /opt/vault/tls
+      cd /etc/vault.d/certs
 
-      cp /etc/consul.d/certs/* .
-
-      consul tls cert create -server -additional-ipaddress $(ip -json -4 addr show lima0  | jq -r '.[] | .addr_info[].local') -additional-dnsname ${HOSTNAME}.local
-
-      chown vault:vault /opt/vault/tls/*
+      consul tls cert create -domain vault -server -additional-ipaddress $(ip -json -4 addr show lima0  | jq -r '.[] | .addr_info[].local') -additional-dnsname ${HOSTNAME}.local
+      
+      chown -R vault:vault /etc/vault.d/certs/*
 
   - mode: system # configure Vault Server
     script: |
@@ -49,9 +47,9 @@ provision:
         $(for x in $(seq $SHIKARI_SERVER_COUNT); do
         echo retry_join {
         echo leader_api_addr      = \"https://lima-${SHIKARI_CLUSTER_NAME}-srv-0$x.local:8200\"
-        echo leader_ca_cert_file  = \"/opt/vault/tls/consul-agent-ca.pem\"
-        echo leader_client_cert_  = \"/opt/vault/tls/dc1-server-consul-0.pem\"
-        echo leader_client_kile   = \"/opt/vault/tls/dc1-server-consul-0-key.pem\"
+        echo leader_ca_cert_file  = \"/etc/vault.d/certs/vault-agent-ca.pem\"
+        echo leader_client_cert_  = \"/etc/vault.d/certs/dc1-server-vault-0.pem\"
+        echo leader_client_kile   = \"/etc/vault.d/certs/dc1-server-vault-0-key.pem\"
         echo }
        done)
       }
@@ -59,9 +57,9 @@ provision:
       listener "tcp" {
         address       = "0.0.0.0:8200"
         
-        tls_cert_file       = "/opt/vault/tls/dc1-server-consul-0.pem"
-        tls_key_file        = "/opt/vault/tls/dc1-server-consul-0-key.pem"
-        tls_client_ca_file  = "/opt/vault/tls/consul-agent-ca.pem"
+        tls_cert_file       = "/etc/vault.d/certs/dc1-server-vault-0.pem"
+        tls_key_file        = "/etc/vault.d/certs/dc1-server-vault-0-key.pem"
+        tls_client_ca_file  = "/etc/vault.d/certs/vault-agent-ca.pem"
         
         cluster_address = "0.0.0.0:8201"
       }
@@ -88,11 +86,11 @@ provision:
       fi
 
       export VAULT_ADDR=https://127.0.0.1:8200
-      export VAULT_CACERT=/opt/vault/tls/consul-agent-ca.pem
+      export VAULT_CACERT=/etc/vault.d/certs/vault-agent-ca.pem
       
       if [[ "$HOSTNAME" == *"01"* ]]; then
         
-        until curl -s --cacert /opt/vault/tls/consul-agent-ca.pem $VAULT_ADDR/v1/sys/health; do
+        until curl -s --cacert /etc/vault.d/certs/vault-agent-ca.pem $VAULT_ADDR/v1/sys/health; do
           echo "Waiting for Vault"
         done
 


### PR DESCRIPTION
fixes: #61

This PR moves the Vault Cert directory from `/opt/vault/certs` to `/etc/vault.d/certs`.

This will bring consistency with how other product certs are managed.

All the Vault Scenarios have been updated to use the new path.