### PR TITLE
Move consul config  from tls.default to tls.internal_rpc stanza

### DIFF
--- a/scenarios/nomad-consul-secure/hashibox.yaml
+++ b/scenarios/nomad-consul-secure/hashibox.yaml
@@ -105,9 +105,11 @@ provision:
             ca_file = "/etc/consul.d/certs/consul-agent-ca.pem"
             cert_file = "/etc/consul.d/certs/${SHIKARI_CLUSTER_NAME}-${SHIKARI_VM_MODE}-consul-0.pem"
             key_file = "/etc/consul.d/certs/${SHIKARI_CLUSTER_NAME}-${SHIKARI_VM_MODE}-consul-0-key.pem"
-            verify_server_hostname = true
             verify_incoming = true
             verify_outgoing = true
+          }
+          internal_rpc {
+            verify_server_hostname = true
           }
           grpc {
             verify_incoming = false

--- a/scenarios/nomad-consul-vault-secure/hashibox.yaml
+++ b/scenarios/nomad-consul-vault-secure/hashibox.yaml
@@ -317,9 +317,11 @@ provision:
             ca_file = "/etc/consul.d/certs/consul-agent-ca.pem"
             cert_file = "/etc/consul.d/certs/${SHIKARI_CLUSTER_NAME}-${SHIKARI_VM_MODE}-consul-0.pem"
             key_file = "/etc/consul.d/certs/${SHIKARI_CLUSTER_NAME}-${SHIKARI_VM_MODE}-consul-0-key.pem"
-            verify_server_hostname = true
             verify_incoming = true
             verify_outgoing = true
+          }
+          internal_rpc {
+            verify_server_hostname = true
           }
           grpc {
             verify_incoming = false


### PR DESCRIPTION
Move consul config  from tls.default to tls.internal_rpc stanza. Updated scenarios : 
- nomad-consul-secure/hashibox.yaml
- nomad-consul-vault-secure/hashibox.yaml